### PR TITLE
 overlay: power_profile: Fix battery capacity

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -35,7 +35,7 @@
     <array name="memory.bandwidths">
         <value>22.7</value>
     </array>
-    <item name="battery.capacity">1000</item>
+    <item name="battery.capacity">4500</item>
     <item name="wifi.controller.idle">0</item>
     <item name="wifi.controller.rx">0</item>
     <item name="wifi.controller.tx">0</item>


### PR DESCRIPTION
Xperia 10III (PDX213) has a battery capacity of 4500mAh and not 1000mAh,

Change this value so system reports correct value.