### PR TITLE
mixer_paths: Use handset mic for loudspeaker mode workaround

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -3665,16 +3665,7 @@
     </path>
 
     <path name="speaker-dmic-endfire">
-        <ctl name="TX_CDC_DMA_TX_3 Channels" value="Two" />
-        <ctl name="TX DEC1 MUX" value="SWR_MIC" />
-        <ctl name="TX SMIC MUX1" value="ADC3" />
-        <ctl name="TX_AIF1_CAP Mixer DEC1" value="1" />
-        <ctl name="ADC3_MIXER Switch" value="1" />
-        <ctl name="TX DEC2 MUX" value="SWR_MIC" />
-        <ctl name="TX SMIC MUX2" value="ADC2" />
-        <ctl name="TX_AIF1_CAP Mixer DEC2" value="1" />
-        <ctl name="ADC2_MIXER Switch" value="1" />
-        <ctl name="ADC2 MUX" value="INP3" />
+        <path name="handset-dmic-endfire" />
     </path>
 
     <path name="stereo-mic">


### PR DESCRIPTION
Microphone is muted with loudspeaker route during voice calls and VoIP
calls. As a workaround use handset mic config for the loudspeaker use
case as well.

Works around https://github.com/sonyxperiadev/bug_tracker/issues/745.